### PR TITLE
Fix a typo in main.js

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -42,5 +42,5 @@ if (!process.argv.slice(2).length) {
 
 // Check if there is a token on the arguments.
 if (Program.token) {
-  Command.setToken(Program.token);
+  Commands.setToken(Program.token);
 }


### PR DESCRIPTION
A typo in main.js cause token feature not working (Fix: Renamed Command to Commands)
